### PR TITLE
Fix for content-type in example.

### DIFF
--- a/DecisionManagement/modelPublish.md
+++ b/DecisionManagement/modelPublish.md
@@ -76,7 +76,7 @@ Here is an example of creating a definition for a SAS Micro Analytic Service pub
 {
   "POST": "/modelPublish/destinations",
   "headers": {
-    "Content-Type": "application/vnd.sas.models.publishing.destination.cas",
+    "Content-Type": "application/vnd.sas.models.publishing.destination.mas",
     "Accept": "application/vnd.sas.models.publishing.destination+json"
   },
   "body": {


### PR DESCRIPTION
Small fix to correct the contentType in the example for the SAS Micro Analytic Service publishing destination.